### PR TITLE
Enhance labs with diagrams and exercises

### DIFF
--- a/notebooks/02_Data_Preprocessing.ipynb
+++ b/notebooks/02_Data_Preprocessing.ipynb
@@ -17,6 +17,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "40c43e3c",
+   "metadata": {},
+   "source": [
+    "### Data Preprocessing Workflow\n",
+    "```text\n",
+    "Raw Data -> [Cleaning] -> [Encoding] -> [Scaling] -> Processed Data\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "a9637d7a",
@@ -291,6 +302,15 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2b83d1ec",
+   "metadata": {},
+   "source": [
+    "### Results and Interpretation\n",
+    "The PCA visualization above illustrates how preprocessing condenses information while preserving class structure. Standardization, imputation, and scaling make feature ranges comparable, enabling clearer clustering in the reduced space."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "9e2b4c1c",
    "metadata": {},
    "source": [
@@ -358,11 +378,12 @@
    "metadata": {},
    "source": [
     "### Exercises\n",
-    "\n",
     "1. Use `SimpleImputer` to replace missing values in a dataset and compare model performance with and without imputation.\n",
     "2. Apply `MinMaxScaler` to a dataset with skewed features and plot histograms before and after scaling.\n",
     "3. Combine preprocessing steps in a `ColumnTransformer` that handles numeric and categorical data.\n",
-    "4. Explore how `RobustScaler` affects models when outliers are present."
+    "4. Explore how `RobustScaler` affects models when outliers are present.\n",
+    "5. Implement PCA to reduce the dataset to two components and visualize the result.\n",
+    "6. Create a custom transformer that applies a log transform to skewed features."
    ]
   }
  ],

--- a/notebooks/03_Regression_Models.ipynb
+++ b/notebooks/03_Regression_Models.ipynb
@@ -18,6 +18,17 @@
   },
   {
    "cell_type": "markdown",
+   "id": "eeaad348",
+   "metadata": {},
+   "source": [
+    "### Regression Pipeline Overview\n",
+    "```text\n",
+    "Data -> [Train/Test Split] -> [Train Model] -> [Predict] -> [Evaluate]\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "linregformula",
    "metadata": {},
    "source": [
@@ -63,6 +74,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "91f17746",
    "metadata": {},
    "source": [
     "### Ridge Regression\n",
@@ -72,7 +84,10 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "abe620c5",
    "metadata": {},
+   "outputs": [],
    "source": [
     "from sklearn.linear_model import Ridge\n",
     "ridge=Ridge(alpha=1.0).fit(X_train,y_train)\n",
@@ -81,6 +96,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f93dd139",
    "metadata": {},
    "source": [
     "### Lasso Regression\n",
@@ -90,7 +106,10 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "c16801b0",
    "metadata": {},
+   "outputs": [],
    "source": [
     "from sklearn.linear_model import Lasso\n",
     "lasso=Lasso(alpha=0.1).fit(X_train,y_train)\n",
@@ -149,6 +168,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "90beb02e",
+   "metadata": {},
+   "source": [
+    "### Results and Interpretation\n",
+    "The prediction snippet above demonstrates how the trained regression model outputs continuous values for new samples. Interpreting coefficients helps identify feature influence, while residual analysis reveals model fit quality."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32684d90-8ef7-4b57-9836-9730283aa0b0",
    "metadata": {},
    "source": [
     "### Linear Regression Refresher\n",
@@ -164,11 +193,11 @@
     "which has the closed-form solution (normal equation):\n",
     "\n",
     "$$\\hat{\\beta} = (X^\\top X)^{-1} X^\\top y.$$\n"
-   ],
-   "id": "32684d90-8ef7-4b57-9836-9730283aa0b0"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "c6ec2055-d124-4b3b-b409-22d2992f1559",
    "metadata": {},
    "source": [
     "### Worked Example: Interpreting Coefficients\n",
@@ -187,8 +216,7 @@
     "```\n",
     "\n",
     "The intercept represents the predicted price for a home with zero square feet, and the coefficient indicates the expected change in price for each additional square foot. The final line predicts the price for a 900 square-foot home.\n"
-   ],
-   "id": "c6ec2055-d124-4b3b-b409-22d2992f1559"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -198,10 +226,12 @@
     "### Exercises & Further Reading\n",
     "1. Add Ridge/Lasso.\n",
     "2. Perform cross validation.\n",
-    "3. [sklearn linear models](https://scikit-learn.org/stable/modules/linear_model.html)",
+    "3. [sklearn linear models](https://scikit-learn.org/stable/modules/linear_model.html)\n",
     "4. Plot residuals for a fitted model and comment on any patterns.\n",
     "5. Use `PolynomialFeatures` to fit a quadratic curve and compare it to the linear fit.\n",
-    "6. Derive the normal equation yourself and verify the solution using NumPy.\n"
+    "6. Derive the normal equation yourself and verify the solution using NumPy.\n",
+    "7. Implement `ElasticNet` and compare its performance to Ridge and Lasso.\n",
+    "8. Evaluate the model using mean absolute error and compare it with mean squared error."
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- add workflow diagrams and interpretation sections to data preprocessing and regression notebooks
- expand exercise sections for deeper practice

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688de9da3ce88326a7e2e741d3b19852