### PR TITLE
Expand exam with additional lab-based tasks

### DIFF
--- a/exam/Abdallah_Nizar.ipynb
+++ b/exam/Abdallah_Nizar.ipynb
@@ -22,7 +22,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -83,7 +83,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. What are model parameters?\n3. What are coefficients and intercepts?\n4. How does linear regression work?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n\n- Convert all column names to lowercase.\n- Ensure column names have no spaces.\n- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n\n- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. What are model parameters?\n3. What are coefficients and intercepts?\n4. How does linear regression work?\n5. Compare conda and pip for environment management.\n6. Define MCAR, MAR, and MNAR.\n\nWrite your answers below.\n"
    ]
   },
   {

--- a/exam/Adham_Mohamed_Kattara.ipynb
+++ b/exam/Adham_Mohamed_Kattara.ipynb
@@ -22,7 +22,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -83,7 +83,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. What is a correlation matrix?\n2. What are model parameters?\n3. How does linear regression work?\n4. What is the learning rate?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n\n- Convert all column names to lowercase.\n- Ensure column names have no spaces.\n- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n\n- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. What are model parameters?\n3. What are coefficients and intercepts?\n4. How does linear regression work?\n5. Compare conda and pip for environment management.\n6. Define MCAR, MAR, and MNAR.\n\nWrite your answers below.\n"
    ]
   },
   {

--- a/exam/Ahmed_Mosaad.ipynb
+++ b/exam/Ahmed_Mosaad.ipynb
@@ -22,7 +22,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -83,7 +83,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. What are model parameters?\n2. What are coefficients and intercepts?\n3. How does linear regression work?\n4. What is the learning rate?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n\n- Convert all column names to lowercase.\n- Ensure column names have no spaces.\n- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n\n- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. What are model parameters?\n3. What are coefficients and intercepts?\n4. How does linear regression work?\n5. Compare conda and pip for environment management.\n6. Define MCAR, MAR, and MNAR.\n\nWrite your answers below.\n"
    ]
   },
   {

--- a/exam/Alaa_Rafiek.ipynb
+++ b/exam/Alaa_Rafiek.ipynb
@@ -22,7 +22,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -83,7 +83,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. How are training and testing performed?\n2. What are coefficients and intercepts?\n3. What is the learning rate?\n4. What is mean squared error (MSE)?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n\n- Convert all column names to lowercase.\n- Ensure column names have no spaces.\n- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n\n- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. What are model parameters?\n3. What are coefficients and intercepts?\n4. How does linear regression work?\n5. Compare conda and pip for environment management.\n6. Define MCAR, MAR, and MNAR.\n\nWrite your answers below.\n"
    ]
   },
   {

--- a/exam/Hana_Ahmed.ipynb
+++ b/exam/Hana_Ahmed.ipynb
@@ -22,7 +22,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -83,7 +83,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. How are training and testing performed?\n3. What is a correlation matrix?\n4. What does the variance of the data indicate?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n\n- Convert all column names to lowercase.\n- Ensure column names have no spaces.\n- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n\n- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. What are model parameters?\n3. What are coefficients and intercepts?\n4. How does linear regression work?\n5. Compare conda and pip for environment management.\n6. Define MCAR, MAR, and MNAR.\n\nWrite your answers below.\n"
    ]
   },
   {

--- a/exam/Haneen_Magdy.ipynb
+++ b/exam/Haneen_Magdy.ipynb
@@ -22,7 +22,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -83,7 +83,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. How are training and testing performed?\n3. What are model parameters?\n4. What is mean squared error (MSE)?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n\n- Convert all column names to lowercase.\n- Ensure column names have no spaces.\n- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n\n- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. What are model parameters?\n3. What are coefficients and intercepts?\n4. How does linear regression work?\n5. Compare conda and pip for environment management.\n6. Define MCAR, MAR, and MNAR.\n\nWrite your answers below.\n"
    ]
   },
   {

--- a/exam/Karim_Adel.ipynb
+++ b/exam/Karim_Adel.ipynb
@@ -22,7 +22,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -83,7 +83,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. What are coefficients and intercepts?\n3. How does linear regression work?\n4. What is the learning rate?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n\n- Convert all column names to lowercase.\n- Ensure column names have no spaces.\n- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n\n- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. What are model parameters?\n3. What are coefficients and intercepts?\n4. How does linear regression work?\n5. Compare conda and pip for environment management.\n6. Define MCAR, MAR, and MNAR.\n\nWrite your answers below.\n"
    ]
   },
   {

--- a/exam/Mariam_Khaled.ipynb
+++ b/exam/Mariam_Khaled.ipynb
@@ -22,7 +22,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -83,7 +83,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. What is a correlation matrix?\n3. What are model parameters?\n4. What is mean squared error (MSE)?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n\n- Convert all column names to lowercase.\n- Ensure column names have no spaces.\n- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n\n- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. What are model parameters?\n3. What are coefficients and intercepts?\n4. How does linear regression work?\n5. Compare conda and pip for environment management.\n6. Define MCAR, MAR, and MNAR.\n\nWrite your answers below.\n"
    ]
   },
   {

--- a/exam/Mohamed_Abdelkhalek.ipynb
+++ b/exam/Mohamed_Abdelkhalek.ipynb
@@ -22,7 +22,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -83,7 +83,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. How are training and testing performed?\n2. What does the variance of the data indicate?\n3. What are coefficients and intercepts?\n4. How does linear regression work?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n\n- Convert all column names to lowercase.\n- Ensure column names have no spaces.\n- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n\n- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. What are model parameters?\n3. What are coefficients and intercepts?\n4. How does linear regression work?\n5. Compare conda and pip for environment management.\n6. Define MCAR, MAR, and MNAR.\n\nWrite your answers below.\n"
    ]
   },
   {

--- a/exam/Mohanad_Ayman.ipynb
+++ b/exam/Mohanad_Ayman.ipynb
@@ -22,7 +22,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -83,7 +83,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. What is a correlation matrix?\n2. What does the variance of the data indicate?\n3. How does linear regression work?\n4. What is mean squared error (MSE)?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n\n- Convert all column names to lowercase.\n- Ensure column names have no spaces.\n- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n\n- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. What are model parameters?\n3. What are coefficients and intercepts?\n4. How does linear regression work?\n5. Compare conda and pip for environment management.\n6. Define MCAR, MAR, and MNAR.\n\nWrite your answers below.\n"
    ]
   },
   {

--- a/exam/Mostafa_Abdelghany.ipynb
+++ b/exam/Mostafa_Abdelghany.ipynb
@@ -22,7 +22,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -83,7 +83,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. How are training and testing performed?\n3. What does the variance of the data indicate?\n4. What is mean squared error (MSE)?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n\n- Convert all column names to lowercase.\n- Ensure column names have no spaces.\n- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n\n- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. What are model parameters?\n3. What are coefficients and intercepts?\n4. How does linear regression work?\n5. Compare conda and pip for environment management.\n6. Define MCAR, MAR, and MNAR.\n\nWrite your answers below.\n"
    ]
   },
   {

--- a/exam/Omar_Khaled.ipynb
+++ b/exam/Omar_Khaled.ipynb
@@ -22,7 +22,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -83,7 +83,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. How are training and testing performed?\n2. What is a correlation matrix?\n3. How does linear regression work?\n4. What is mean squared error (MSE)?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n\n- Convert all column names to lowercase.\n- Ensure column names have no spaces.\n- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n\n- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. What are model parameters?\n3. What are coefficients and intercepts?\n4. How does linear regression work?\n5. Compare conda and pip for environment management.\n6. Define MCAR, MAR, and MNAR.\n\nWrite your answers below.\n"
    ]
   },
   {

--- a/exam/Raneem_Mohammed.ipynb
+++ b/exam/Raneem_Mohammed.ipynb
@@ -22,7 +22,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -83,7 +83,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. How are training and testing performed?\n3. What is a correlation matrix?\n4. How does linear regression work?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n\n- Convert all column names to lowercase.\n- Ensure column names have no spaces.\n- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n\n- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. What are model parameters?\n3. What are coefficients and intercepts?\n4. How does linear regression work?\n5. Compare conda and pip for environment management.\n6. Define MCAR, MAR, and MNAR.\n\nWrite your answers below.\n"
    ]
   },
   {

--- a/exam/Taha_Yassin_Mohamed.ipynb
+++ b/exam/Taha_Yassin_Mohamed.ipynb
@@ -22,7 +22,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -83,7 +83,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. How are training and testing performed?\n3. What are coefficients and intercepts?\n4. What is the learning rate?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n\n- Convert all column names to lowercase.\n- Ensure column names have no spaces.\n- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n\n- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. What are model parameters?\n3. What are coefficients and intercepts?\n4. How does linear regression work?\n5. Compare conda and pip for environment management.\n6. Define MCAR, MAR, and MNAR.\n\nWrite your answers below.\n"
    ]
   },
   {

--- a/exam/Yahya_Gad.ipynb
+++ b/exam/Yahya_Gad.ipynb
@@ -22,7 +22,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -83,7 +83,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. What is a correlation matrix?\n3. What does the variance of the data indicate?\n4. How does linear regression work?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n\n- Convert all column names to lowercase.\n- Ensure column names have no spaces.\n- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n\n- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. What are model parameters?\n3. What are coefficients and intercepts?\n4. How does linear regression work?\n5. Compare conda and pip for environment management.\n6. Define MCAR, MAR, and MNAR.\n\nWrite your answers below.\n"
    ]
   },
   {

--- a/exam/Yaseen_Moataz.ipynb
+++ b/exam/Yaseen_Moataz.ipynb
@@ -22,7 +22,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -83,7 +83,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. How are training and testing performed?\n2. What are model parameters?\n3. How does linear regression work?\n4. What is mean squared error (MSE)?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n\n- Convert all column names to lowercase.\n- Ensure column names have no spaces.\n- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n\n- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. What are model parameters?\n3. What are coefficients and intercepts?\n4. How does linear regression work?\n5. Compare conda and pip for environment management.\n6. Define MCAR, MAR, and MNAR.\n\nWrite your answers below.\n"
    ]
   },
   {

--- a/exam/Youssef_Khaled.ipynb
+++ b/exam/Youssef_Khaled.ipynb
@@ -22,7 +22,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -83,7 +83,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. How are training and testing performed?\n2. What are coefficients and intercepts?\n3. How does linear regression work?\n4. What is mean squared error (MSE)?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n\n- Convert all column names to lowercase.\n- Ensure column names have no spaces.\n- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n\n- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. What are model parameters?\n3. What are coefficients and intercepts?\n4. How does linear regression work?\n5. Compare conda and pip for environment management.\n6. Define MCAR, MAR, and MNAR.\n\nWrite your answers below.\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Add column naming inconsistency to the exam dataset and tasks prompting column standardization.
- Introduce reproducibility function exercise and expand written questions with environment and missingness topics.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688dfc3bf60c832683bc92b6669f672a