### PR TITLE
Expand exam with additional lab-based tasks

### DIFF
--- a/exam/Abdallah_Nizar.ipynb
+++ b/exam/Abdallah_Nizar.ipynb
@@ -2,15 +2,19 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "90d1eec6",
    "metadata": {},
    "source": [
-    "# Exam for Abdallah Nizar\n\nThis exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
+    "# Exam for Abdallah Nizar\n",
+    "\n",
+    "This exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "2b15bf09",
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -22,7 +26,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -33,15 +37,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "98cbddaa",
    "metadata": {},
    "source": [
-    "## Task 1: Data Cleaning\n\n- Handle missing values.\n- Remove duplicate rows.\n- Address outliers.\n- Document each step.\n"
+    "## Task 1: Data Cleaning\n",
+    "\n",
+    "- Handle missing values.\n",
+    "- Remove duplicate rows.\n",
+    "- Address outliers.\n",
+    "- Document each step.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "8b15fa99",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your data cleaning code here\n"
@@ -49,15 +60,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1726dff1",
    "metadata": {},
    "source": [
-    "## Task 2: Summaries and Normalization\n\n- Provide summary statistics.\n- Normalize the numeric columns.\n- Explain the changes after normalization.\n"
+    "## Task 2: Summaries and Normalization\n",
+    "\n",
+    "- Provide summary statistics.\n",
+    "- Normalize the numeric columns.\n",
+    "- Explain the changes after normalization.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "0a647846",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your code for summary and normalization here\n"
@@ -65,15 +82,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5c8ca9da",
    "metadata": {},
    "source": [
-    "## Task 3: Plotting\n\n- Plot histograms for each numeric column.\n- Create a scatter plot comparing two columns of your choice.\n- Comment on the patterns you observe.\n"
+    "## Task 3: Plotting\n",
+    "\n",
+    "- Plot histograms for each numeric column.\n",
+    "- Create a scatter plot comparing two columns of your choice.\n",
+    "- Comment on the patterns you observe.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "6dbaa160",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your plotting code here\n"
@@ -81,13 +104,113 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2bfc7f5d",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. What are model parameters?\n3. What are coefficients and intercepts?\n4. How does linear regression work?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n",
+    "\n",
+    "- Convert all column names to lowercase.\n",
+    "- Ensure column names have no spaces.\n",
+    "- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41e3ff95",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "9f84fb1b",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n",
+    "\n",
+    "- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n",
+    "- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60104602",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "585b48f6",
+   "metadata": {},
+   "source": [
+    "## Task 6: Filtering and Grouping\n",
+    "\n",
+    "- Filter rows where `A` is greater than 0 and `C` is not `NaN`.\n",
+    "- Group the filtered data by `C` and compute the mean of `B` for each group.\n",
+    "- Discuss any patterns you observe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f818186a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for filtering and grouping here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79624445",
+   "metadata": {},
+   "source": [
+    "## Task 7: Feature Engineering with `np.where`\n",
+    "\n",
+    "- Create a new column `a_label` that labels values of `A` as `'high'` if above the mean, otherwise `'low'`.\n",
+    "- Use `np.where` to implement the labeling.\n",
+    "- Display the count of each label."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b3ac1c6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your feature engineering code here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34d0dbcf",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n",
+    "\n",
+    "1. Describe the machine learning workflow.\n",
+    "2. What are model parameters?\n",
+    "3. What are coefficients and intercepts?\n",
+    "4. How does linear regression work?\n",
+    "5. Compare conda and pip for environment management.\n",
+    "6. Define MCAR, MAR, and MNAR.\n",
+    "7. When would you choose median imputation over mean, and why?\n",
+    "8. Which missingness type applies when the probability of missingness depends on the unobserved value itself?\n",
+    "\n",
+    "Write your answers below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7738cfe9",
    "metadata": {},
    "source": [
     "*Your answers here.*\n"

--- a/exam/Adham_Mohamed_Kattara.ipynb
+++ b/exam/Adham_Mohamed_Kattara.ipynb
@@ -2,15 +2,19 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "75631cbc",
    "metadata": {},
    "source": [
-    "# Exam for Adham Mohamed Kattara\n\nThis exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
+    "# Exam for Adham Mohamed Kattara\n",
+    "\n",
+    "This exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "34b1eb52",
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -22,7 +26,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -33,15 +37,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "80f36385",
    "metadata": {},
    "source": [
-    "## Task 1: Data Cleaning\n\n- Handle missing values.\n- Remove duplicate rows.\n- Address outliers.\n- Document each step.\n"
+    "## Task 1: Data Cleaning\n",
+    "\n",
+    "- Handle missing values.\n",
+    "- Remove duplicate rows.\n",
+    "- Address outliers.\n",
+    "- Document each step.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "7eb52e32",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your data cleaning code here\n"
@@ -49,15 +60,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "32745109",
    "metadata": {},
    "source": [
-    "## Task 2: Summaries and Normalization\n\n- Provide summary statistics.\n- Normalize the numeric columns.\n- Explain the changes after normalization.\n"
+    "## Task 2: Summaries and Normalization\n",
+    "\n",
+    "- Provide summary statistics.\n",
+    "- Normalize the numeric columns.\n",
+    "- Explain the changes after normalization.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "125e3d43",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your code for summary and normalization here\n"
@@ -65,15 +82,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ad019539",
    "metadata": {},
    "source": [
-    "## Task 3: Plotting\n\n- Plot histograms for each numeric column.\n- Create a scatter plot comparing two columns of your choice.\n- Comment on the patterns you observe.\n"
+    "## Task 3: Plotting\n",
+    "\n",
+    "- Plot histograms for each numeric column.\n",
+    "- Create a scatter plot comparing two columns of your choice.\n",
+    "- Comment on the patterns you observe.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "d460bf72",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your plotting code here\n"
@@ -81,13 +104,113 @@
   },
   {
    "cell_type": "markdown",
+   "id": "883add74",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. What is a correlation matrix?\n2. What are model parameters?\n3. How does linear regression work?\n4. What is the learning rate?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n",
+    "\n",
+    "- Convert all column names to lowercase.\n",
+    "- Ensure column names have no spaces.\n",
+    "- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ebc80ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "e201b764",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n",
+    "\n",
+    "- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n",
+    "- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bbbf9c55",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd296fcc",
+   "metadata": {},
+   "source": [
+    "## Task 6: Filtering and Grouping\n",
+    "\n",
+    "- Filter rows where `A` is greater than 0 and `C` is not `NaN`.\n",
+    "- Group the filtered data by `C` and compute the mean of `B` for each group.\n",
+    "- Discuss any patterns you observe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d7ba021b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for filtering and grouping here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2577550",
+   "metadata": {},
+   "source": [
+    "## Task 7: Feature Engineering with `np.where`\n",
+    "\n",
+    "- Create a new column `a_label` that labels values of `A` as `'high'` if above the mean, otherwise `'low'`.\n",
+    "- Use `np.where` to implement the labeling.\n",
+    "- Display the count of each label."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2efea884",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your feature engineering code here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c24870fd",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n",
+    "\n",
+    "1. Describe the machine learning workflow.\n",
+    "2. What are model parameters?\n",
+    "3. What are coefficients and intercepts?\n",
+    "4. How does linear regression work?\n",
+    "5. Compare conda and pip for environment management.\n",
+    "6. Define MCAR, MAR, and MNAR.\n",
+    "7. When would you choose median imputation over mean, and why?\n",
+    "8. Which missingness type applies when the probability of missingness depends on the unobserved value itself?\n",
+    "\n",
+    "Write your answers below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a582e655",
    "metadata": {},
    "source": [
     "*Your answers here.*\n"

--- a/exam/Ahmed_Mosaad.ipynb
+++ b/exam/Ahmed_Mosaad.ipynb
@@ -2,15 +2,19 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "3a0a6d74",
    "metadata": {},
    "source": [
-    "# Exam for Ahmed Mosaad\n\nThis exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
+    "# Exam for Ahmed Mosaad\n",
+    "\n",
+    "This exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "de8f81eb",
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -22,7 +26,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -33,15 +37,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "63c8e8b4",
    "metadata": {},
    "source": [
-    "## Task 1: Data Cleaning\n\n- Handle missing values.\n- Remove duplicate rows.\n- Address outliers.\n- Document each step.\n"
+    "## Task 1: Data Cleaning\n",
+    "\n",
+    "- Handle missing values.\n",
+    "- Remove duplicate rows.\n",
+    "- Address outliers.\n",
+    "- Document each step.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "fb62911f",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your data cleaning code here\n"
@@ -49,15 +60,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b0162724",
    "metadata": {},
    "source": [
-    "## Task 2: Summaries and Normalization\n\n- Provide summary statistics.\n- Normalize the numeric columns.\n- Explain the changes after normalization.\n"
+    "## Task 2: Summaries and Normalization\n",
+    "\n",
+    "- Provide summary statistics.\n",
+    "- Normalize the numeric columns.\n",
+    "- Explain the changes after normalization.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "c73a3780",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your code for summary and normalization here\n"
@@ -65,15 +82,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ac91941d",
    "metadata": {},
    "source": [
-    "## Task 3: Plotting\n\n- Plot histograms for each numeric column.\n- Create a scatter plot comparing two columns of your choice.\n- Comment on the patterns you observe.\n"
+    "## Task 3: Plotting\n",
+    "\n",
+    "- Plot histograms for each numeric column.\n",
+    "- Create a scatter plot comparing two columns of your choice.\n",
+    "- Comment on the patterns you observe.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "fcfe831b",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your plotting code here\n"
@@ -81,13 +104,113 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0ae08205",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. What are model parameters?\n2. What are coefficients and intercepts?\n3. How does linear regression work?\n4. What is the learning rate?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n",
+    "\n",
+    "- Convert all column names to lowercase.\n",
+    "- Ensure column names have no spaces.\n",
+    "- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "621faec8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "2cae904f",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n",
+    "\n",
+    "- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n",
+    "- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d733137f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f19c0c79",
+   "metadata": {},
+   "source": [
+    "## Task 6: Filtering and Grouping\n",
+    "\n",
+    "- Filter rows where `A` is greater than 0 and `C` is not `NaN`.\n",
+    "- Group the filtered data by `C` and compute the mean of `B` for each group.\n",
+    "- Discuss any patterns you observe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "217b4646",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for filtering and grouping here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a34ebb4",
+   "metadata": {},
+   "source": [
+    "## Task 7: Feature Engineering with `np.where`\n",
+    "\n",
+    "- Create a new column `a_label` that labels values of `A` as `'high'` if above the mean, otherwise `'low'`.\n",
+    "- Use `np.where` to implement the labeling.\n",
+    "- Display the count of each label."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "574aab8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your feature engineering code here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c3a6006",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n",
+    "\n",
+    "1. Describe the machine learning workflow.\n",
+    "2. What are model parameters?\n",
+    "3. What are coefficients and intercepts?\n",
+    "4. How does linear regression work?\n",
+    "5. Compare conda and pip for environment management.\n",
+    "6. Define MCAR, MAR, and MNAR.\n",
+    "7. When would you choose median imputation over mean, and why?\n",
+    "8. Which missingness type applies when the probability of missingness depends on the unobserved value itself?\n",
+    "\n",
+    "Write your answers below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f5f30903",
    "metadata": {},
    "source": [
     "*Your answers here.*\n"

--- a/exam/Alaa_Rafiek.ipynb
+++ b/exam/Alaa_Rafiek.ipynb
@@ -2,15 +2,19 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "f7c5ace6",
    "metadata": {},
    "source": [
-    "# Exam for Alaa Rafiek\n\nThis exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
+    "# Exam for Alaa Rafiek\n",
+    "\n",
+    "This exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "ae6b9099",
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -22,7 +26,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -33,15 +37,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d43577ef",
    "metadata": {},
    "source": [
-    "## Task 1: Data Cleaning\n\n- Handle missing values.\n- Remove duplicate rows.\n- Address outliers.\n- Document each step.\n"
+    "## Task 1: Data Cleaning\n",
+    "\n",
+    "- Handle missing values.\n",
+    "- Remove duplicate rows.\n",
+    "- Address outliers.\n",
+    "- Document each step.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "869711f9",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your data cleaning code here\n"
@@ -49,15 +60,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e743fd1c",
    "metadata": {},
    "source": [
-    "## Task 2: Summaries and Normalization\n\n- Provide summary statistics.\n- Normalize the numeric columns.\n- Explain the changes after normalization.\n"
+    "## Task 2: Summaries and Normalization\n",
+    "\n",
+    "- Provide summary statistics.\n",
+    "- Normalize the numeric columns.\n",
+    "- Explain the changes after normalization.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "234d0036",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your code for summary and normalization here\n"
@@ -65,15 +82,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b3ea7842",
    "metadata": {},
    "source": [
-    "## Task 3: Plotting\n\n- Plot histograms for each numeric column.\n- Create a scatter plot comparing two columns of your choice.\n- Comment on the patterns you observe.\n"
+    "## Task 3: Plotting\n",
+    "\n",
+    "- Plot histograms for each numeric column.\n",
+    "- Create a scatter plot comparing two columns of your choice.\n",
+    "- Comment on the patterns you observe.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "40b03f57",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your plotting code here\n"
@@ -81,13 +104,113 @@
   },
   {
    "cell_type": "markdown",
+   "id": "dc6eef62",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. How are training and testing performed?\n2. What are coefficients and intercepts?\n3. What is the learning rate?\n4. What is mean squared error (MSE)?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n",
+    "\n",
+    "- Convert all column names to lowercase.\n",
+    "- Ensure column names have no spaces.\n",
+    "- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3bd3c80e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "c3ae54b4",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n",
+    "\n",
+    "- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n",
+    "- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2e5cc826",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac8ccc8e",
+   "metadata": {},
+   "source": [
+    "## Task 6: Filtering and Grouping\n",
+    "\n",
+    "- Filter rows where `A` is greater than 0 and `C` is not `NaN`.\n",
+    "- Group the filtered data by `C` and compute the mean of `B` for each group.\n",
+    "- Discuss any patterns you observe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "847d70a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for filtering and grouping here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d87c5a9f",
+   "metadata": {},
+   "source": [
+    "## Task 7: Feature Engineering with `np.where`\n",
+    "\n",
+    "- Create a new column `a_label` that labels values of `A` as `'high'` if above the mean, otherwise `'low'`.\n",
+    "- Use `np.where` to implement the labeling.\n",
+    "- Display the count of each label."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72e4effc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your feature engineering code here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "118e2bb5",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n",
+    "\n",
+    "1. Describe the machine learning workflow.\n",
+    "2. What are model parameters?\n",
+    "3. What are coefficients and intercepts?\n",
+    "4. How does linear regression work?\n",
+    "5. Compare conda and pip for environment management.\n",
+    "6. Define MCAR, MAR, and MNAR.\n",
+    "7. When would you choose median imputation over mean, and why?\n",
+    "8. Which missingness type applies when the probability of missingness depends on the unobserved value itself?\n",
+    "\n",
+    "Write your answers below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86c4822d",
    "metadata": {},
    "source": [
     "*Your answers here.*\n"

--- a/exam/Hana_Ahmed.ipynb
+++ b/exam/Hana_Ahmed.ipynb
@@ -2,15 +2,19 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "452aadd7",
    "metadata": {},
    "source": [
-    "# Exam for Hana Ahmed\n\nThis exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
+    "# Exam for Hana Ahmed\n",
+    "\n",
+    "This exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "c7a4bf6a",
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -22,7 +26,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -33,15 +37,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cdfa16db",
    "metadata": {},
    "source": [
-    "## Task 1: Data Cleaning\n\n- Handle missing values.\n- Remove duplicate rows.\n- Address outliers.\n- Document each step.\n"
+    "## Task 1: Data Cleaning\n",
+    "\n",
+    "- Handle missing values.\n",
+    "- Remove duplicate rows.\n",
+    "- Address outliers.\n",
+    "- Document each step.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "797e5999",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your data cleaning code here\n"
@@ -49,15 +60,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "69ee05b2",
    "metadata": {},
    "source": [
-    "## Task 2: Summaries and Normalization\n\n- Provide summary statistics.\n- Normalize the numeric columns.\n- Explain the changes after normalization.\n"
+    "## Task 2: Summaries and Normalization\n",
+    "\n",
+    "- Provide summary statistics.\n",
+    "- Normalize the numeric columns.\n",
+    "- Explain the changes after normalization.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "64241e9a",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your code for summary and normalization here\n"
@@ -65,15 +82,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a3722103",
    "metadata": {},
    "source": [
-    "## Task 3: Plotting\n\n- Plot histograms for each numeric column.\n- Create a scatter plot comparing two columns of your choice.\n- Comment on the patterns you observe.\n"
+    "## Task 3: Plotting\n",
+    "\n",
+    "- Plot histograms for each numeric column.\n",
+    "- Create a scatter plot comparing two columns of your choice.\n",
+    "- Comment on the patterns you observe.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "e15add77",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your plotting code here\n"
@@ -81,13 +104,113 @@
   },
   {
    "cell_type": "markdown",
+   "id": "36ef1f8b",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. How are training and testing performed?\n3. What is a correlation matrix?\n4. What does the variance of the data indicate?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n",
+    "\n",
+    "- Convert all column names to lowercase.\n",
+    "- Ensure column names have no spaces.\n",
+    "- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "168884bd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "920608c2",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n",
+    "\n",
+    "- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n",
+    "- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55a8f0f8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "31219449",
+   "metadata": {},
+   "source": [
+    "## Task 6: Filtering and Grouping\n",
+    "\n",
+    "- Filter rows where `A` is greater than 0 and `C` is not `NaN`.\n",
+    "- Group the filtered data by `C` and compute the mean of `B` for each group.\n",
+    "- Discuss any patterns you observe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85426235",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for filtering and grouping here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a129d6be",
+   "metadata": {},
+   "source": [
+    "## Task 7: Feature Engineering with `np.where`\n",
+    "\n",
+    "- Create a new column `a_label` that labels values of `A` as `'high'` if above the mean, otherwise `'low'`.\n",
+    "- Use `np.where` to implement the labeling.\n",
+    "- Display the count of each label."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "572d9591",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your feature engineering code here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02738303",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n",
+    "\n",
+    "1. Describe the machine learning workflow.\n",
+    "2. What are model parameters?\n",
+    "3. What are coefficients and intercepts?\n",
+    "4. How does linear regression work?\n",
+    "5. Compare conda and pip for environment management.\n",
+    "6. Define MCAR, MAR, and MNAR.\n",
+    "7. When would you choose median imputation over mean, and why?\n",
+    "8. Which missingness type applies when the probability of missingness depends on the unobserved value itself?\n",
+    "\n",
+    "Write your answers below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a10d5a5b",
    "metadata": {},
    "source": [
     "*Your answers here.*\n"

--- a/exam/Haneen_Magdy.ipynb
+++ b/exam/Haneen_Magdy.ipynb
@@ -2,15 +2,19 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "ca4d34a8",
    "metadata": {},
    "source": [
-    "# Exam for Haneen Magdy\n\nThis exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
+    "# Exam for Haneen Magdy\n",
+    "\n",
+    "This exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "7b5d848f",
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -22,7 +26,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -33,15 +37,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d92ebd14",
    "metadata": {},
    "source": [
-    "## Task 1: Data Cleaning\n\n- Handle missing values.\n- Remove duplicate rows.\n- Address outliers.\n- Document each step.\n"
+    "## Task 1: Data Cleaning\n",
+    "\n",
+    "- Handle missing values.\n",
+    "- Remove duplicate rows.\n",
+    "- Address outliers.\n",
+    "- Document each step.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "de64da61",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your data cleaning code here\n"
@@ -49,15 +60,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "97112db4",
    "metadata": {},
    "source": [
-    "## Task 2: Summaries and Normalization\n\n- Provide summary statistics.\n- Normalize the numeric columns.\n- Explain the changes after normalization.\n"
+    "## Task 2: Summaries and Normalization\n",
+    "\n",
+    "- Provide summary statistics.\n",
+    "- Normalize the numeric columns.\n",
+    "- Explain the changes after normalization.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "c6aa523f",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your code for summary and normalization here\n"
@@ -65,15 +82,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "71b3d97d",
    "metadata": {},
    "source": [
-    "## Task 3: Plotting\n\n- Plot histograms for each numeric column.\n- Create a scatter plot comparing two columns of your choice.\n- Comment on the patterns you observe.\n"
+    "## Task 3: Plotting\n",
+    "\n",
+    "- Plot histograms for each numeric column.\n",
+    "- Create a scatter plot comparing two columns of your choice.\n",
+    "- Comment on the patterns you observe.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "f2ffeade",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your plotting code here\n"
@@ -81,13 +104,113 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9f75f76a",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. How are training and testing performed?\n3. What are model parameters?\n4. What is mean squared error (MSE)?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n",
+    "\n",
+    "- Convert all column names to lowercase.\n",
+    "- Ensure column names have no spaces.\n",
+    "- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0833fbec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "24535c74",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n",
+    "\n",
+    "- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n",
+    "- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "155a52d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b08292f3",
+   "metadata": {},
+   "source": [
+    "## Task 6: Filtering and Grouping\n",
+    "\n",
+    "- Filter rows where `A` is greater than 0 and `C` is not `NaN`.\n",
+    "- Group the filtered data by `C` and compute the mean of `B` for each group.\n",
+    "- Discuss any patterns you observe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d94c9da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for filtering and grouping here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58512665",
+   "metadata": {},
+   "source": [
+    "## Task 7: Feature Engineering with `np.where`\n",
+    "\n",
+    "- Create a new column `a_label` that labels values of `A` as `'high'` if above the mean, otherwise `'low'`.\n",
+    "- Use `np.where` to implement the labeling.\n",
+    "- Display the count of each label."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7c3c6653",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your feature engineering code here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1fe08aa4",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n",
+    "\n",
+    "1. Describe the machine learning workflow.\n",
+    "2. What are model parameters?\n",
+    "3. What are coefficients and intercepts?\n",
+    "4. How does linear regression work?\n",
+    "5. Compare conda and pip for environment management.\n",
+    "6. Define MCAR, MAR, and MNAR.\n",
+    "7. When would you choose median imputation over mean, and why?\n",
+    "8. Which missingness type applies when the probability of missingness depends on the unobserved value itself?\n",
+    "\n",
+    "Write your answers below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80a14d50",
    "metadata": {},
    "source": [
     "*Your answers here.*\n"

--- a/exam/Karim_Adel.ipynb
+++ b/exam/Karim_Adel.ipynb
@@ -2,15 +2,19 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "bcf6772a",
    "metadata": {},
    "source": [
-    "# Exam for Karim Adel\n\nThis exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
+    "# Exam for Karim Adel\n",
+    "\n",
+    "This exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "763be806",
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -22,7 +26,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -33,15 +37,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "370731b4",
    "metadata": {},
    "source": [
-    "## Task 1: Data Cleaning\n\n- Handle missing values.\n- Remove duplicate rows.\n- Address outliers.\n- Document each step.\n"
+    "## Task 1: Data Cleaning\n",
+    "\n",
+    "- Handle missing values.\n",
+    "- Remove duplicate rows.\n",
+    "- Address outliers.\n",
+    "- Document each step.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "911db067",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your data cleaning code here\n"
@@ -49,15 +60,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ec4ea8a1",
    "metadata": {},
    "source": [
-    "## Task 2: Summaries and Normalization\n\n- Provide summary statistics.\n- Normalize the numeric columns.\n- Explain the changes after normalization.\n"
+    "## Task 2: Summaries and Normalization\n",
+    "\n",
+    "- Provide summary statistics.\n",
+    "- Normalize the numeric columns.\n",
+    "- Explain the changes after normalization.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "549d5c66",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your code for summary and normalization here\n"
@@ -65,15 +82,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0f1fcaa6",
    "metadata": {},
    "source": [
-    "## Task 3: Plotting\n\n- Plot histograms for each numeric column.\n- Create a scatter plot comparing two columns of your choice.\n- Comment on the patterns you observe.\n"
+    "## Task 3: Plotting\n",
+    "\n",
+    "- Plot histograms for each numeric column.\n",
+    "- Create a scatter plot comparing two columns of your choice.\n",
+    "- Comment on the patterns you observe.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "d6d8355d",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your plotting code here\n"
@@ -81,13 +104,113 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0fde8c45",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. What are coefficients and intercepts?\n3. How does linear regression work?\n4. What is the learning rate?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n",
+    "\n",
+    "- Convert all column names to lowercase.\n",
+    "- Ensure column names have no spaces.\n",
+    "- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dbd0d971",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "6656e6e1",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n",
+    "\n",
+    "- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n",
+    "- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "03159f03",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "266ee77b",
+   "metadata": {},
+   "source": [
+    "## Task 6: Filtering and Grouping\n",
+    "\n",
+    "- Filter rows where `A` is greater than 0 and `C` is not `NaN`.\n",
+    "- Group the filtered data by `C` and compute the mean of `B` for each group.\n",
+    "- Discuss any patterns you observe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5fa11288",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for filtering and grouping here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "93eb61a3",
+   "metadata": {},
+   "source": [
+    "## Task 7: Feature Engineering with `np.where`\n",
+    "\n",
+    "- Create a new column `a_label` that labels values of `A` as `'high'` if above the mean, otherwise `'low'`.\n",
+    "- Use `np.where` to implement the labeling.\n",
+    "- Display the count of each label."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3e2ce95f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your feature engineering code here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1afa42c",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n",
+    "\n",
+    "1. Describe the machine learning workflow.\n",
+    "2. What are model parameters?\n",
+    "3. What are coefficients and intercepts?\n",
+    "4. How does linear regression work?\n",
+    "5. Compare conda and pip for environment management.\n",
+    "6. Define MCAR, MAR, and MNAR.\n",
+    "7. When would you choose median imputation over mean, and why?\n",
+    "8. Which missingness type applies when the probability of missingness depends on the unobserved value itself?\n",
+    "\n",
+    "Write your answers below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69589aa4",
    "metadata": {},
    "source": [
     "*Your answers here.*\n"

--- a/exam/Mariam_Khaled.ipynb
+++ b/exam/Mariam_Khaled.ipynb
@@ -2,15 +2,19 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "16d0dd6d",
    "metadata": {},
    "source": [
-    "# Exam for Mariam Khaled\n\nThis exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
+    "# Exam for Mariam Khaled\n",
+    "\n",
+    "This exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "51fd2eef",
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -22,7 +26,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -33,15 +37,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "82593502",
    "metadata": {},
    "source": [
-    "## Task 1: Data Cleaning\n\n- Handle missing values.\n- Remove duplicate rows.\n- Address outliers.\n- Document each step.\n"
+    "## Task 1: Data Cleaning\n",
+    "\n",
+    "- Handle missing values.\n",
+    "- Remove duplicate rows.\n",
+    "- Address outliers.\n",
+    "- Document each step.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "74764195",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your data cleaning code here\n"
@@ -49,15 +60,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b73d1e54",
    "metadata": {},
    "source": [
-    "## Task 2: Summaries and Normalization\n\n- Provide summary statistics.\n- Normalize the numeric columns.\n- Explain the changes after normalization.\n"
+    "## Task 2: Summaries and Normalization\n",
+    "\n",
+    "- Provide summary statistics.\n",
+    "- Normalize the numeric columns.\n",
+    "- Explain the changes after normalization.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "c67a6559",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your code for summary and normalization here\n"
@@ -65,15 +82,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "07f20048",
    "metadata": {},
    "source": [
-    "## Task 3: Plotting\n\n- Plot histograms for each numeric column.\n- Create a scatter plot comparing two columns of your choice.\n- Comment on the patterns you observe.\n"
+    "## Task 3: Plotting\n",
+    "\n",
+    "- Plot histograms for each numeric column.\n",
+    "- Create a scatter plot comparing two columns of your choice.\n",
+    "- Comment on the patterns you observe.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "9d467393",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your plotting code here\n"
@@ -81,13 +104,113 @@
   },
   {
    "cell_type": "markdown",
+   "id": "666ece8a",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. What is a correlation matrix?\n3. What are model parameters?\n4. What is mean squared error (MSE)?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n",
+    "\n",
+    "- Convert all column names to lowercase.\n",
+    "- Ensure column names have no spaces.\n",
+    "- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "be604337",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "1ef43016",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n",
+    "\n",
+    "- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n",
+    "- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "98e8e0f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d912e5a",
+   "metadata": {},
+   "source": [
+    "## Task 6: Filtering and Grouping\n",
+    "\n",
+    "- Filter rows where `A` is greater than 0 and `C` is not `NaN`.\n",
+    "- Group the filtered data by `C` and compute the mean of `B` for each group.\n",
+    "- Discuss any patterns you observe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3239a4b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for filtering and grouping here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3abbb6ab",
+   "metadata": {},
+   "source": [
+    "## Task 7: Feature Engineering with `np.where`\n",
+    "\n",
+    "- Create a new column `a_label` that labels values of `A` as `'high'` if above the mean, otherwise `'low'`.\n",
+    "- Use `np.where` to implement the labeling.\n",
+    "- Display the count of each label."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13a3e54d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your feature engineering code here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08e905e1",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n",
+    "\n",
+    "1. Describe the machine learning workflow.\n",
+    "2. What are model parameters?\n",
+    "3. What are coefficients and intercepts?\n",
+    "4. How does linear regression work?\n",
+    "5. Compare conda and pip for environment management.\n",
+    "6. Define MCAR, MAR, and MNAR.\n",
+    "7. When would you choose median imputation over mean, and why?\n",
+    "8. Which missingness type applies when the probability of missingness depends on the unobserved value itself?\n",
+    "\n",
+    "Write your answers below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f797be2a",
    "metadata": {},
    "source": [
     "*Your answers here.*\n"

--- a/exam/Mohamed_Abdelkhalek.ipynb
+++ b/exam/Mohamed_Abdelkhalek.ipynb
@@ -2,15 +2,19 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "f7cfb864",
    "metadata": {},
    "source": [
-    "# Exam for Mohamed Abdelkhalek\n\nThis exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
+    "# Exam for Mohamed Abdelkhalek\n",
+    "\n",
+    "This exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "f6239155",
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -22,7 +26,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -33,15 +37,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6ce5ec70",
    "metadata": {},
    "source": [
-    "## Task 1: Data Cleaning\n\n- Handle missing values.\n- Remove duplicate rows.\n- Address outliers.\n- Document each step.\n"
+    "## Task 1: Data Cleaning\n",
+    "\n",
+    "- Handle missing values.\n",
+    "- Remove duplicate rows.\n",
+    "- Address outliers.\n",
+    "- Document each step.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "801f9977",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your data cleaning code here\n"
@@ -49,15 +60,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "49b9156d",
    "metadata": {},
    "source": [
-    "## Task 2: Summaries and Normalization\n\n- Provide summary statistics.\n- Normalize the numeric columns.\n- Explain the changes after normalization.\n"
+    "## Task 2: Summaries and Normalization\n",
+    "\n",
+    "- Provide summary statistics.\n",
+    "- Normalize the numeric columns.\n",
+    "- Explain the changes after normalization.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "04e2094e",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your code for summary and normalization here\n"
@@ -65,15 +82,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b39f43c2",
    "metadata": {},
    "source": [
-    "## Task 3: Plotting\n\n- Plot histograms for each numeric column.\n- Create a scatter plot comparing two columns of your choice.\n- Comment on the patterns you observe.\n"
+    "## Task 3: Plotting\n",
+    "\n",
+    "- Plot histograms for each numeric column.\n",
+    "- Create a scatter plot comparing two columns of your choice.\n",
+    "- Comment on the patterns you observe.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "78dc0212",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your plotting code here\n"
@@ -81,13 +104,113 @@
   },
   {
    "cell_type": "markdown",
+   "id": "adc7576b",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. How are training and testing performed?\n2. What does the variance of the data indicate?\n3. What are coefficients and intercepts?\n4. How does linear regression work?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n",
+    "\n",
+    "- Convert all column names to lowercase.\n",
+    "- Ensure column names have no spaces.\n",
+    "- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af903972",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "7a670794",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n",
+    "\n",
+    "- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n",
+    "- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6cab23bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e2aedfe",
+   "metadata": {},
+   "source": [
+    "## Task 6: Filtering and Grouping\n",
+    "\n",
+    "- Filter rows where `A` is greater than 0 and `C` is not `NaN`.\n",
+    "- Group the filtered data by `C` and compute the mean of `B` for each group.\n",
+    "- Discuss any patterns you observe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c26291b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for filtering and grouping here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce388c5a",
+   "metadata": {},
+   "source": [
+    "## Task 7: Feature Engineering with `np.where`\n",
+    "\n",
+    "- Create a new column `a_label` that labels values of `A` as `'high'` if above the mean, otherwise `'low'`.\n",
+    "- Use `np.where` to implement the labeling.\n",
+    "- Display the count of each label."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b5c4af2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your feature engineering code here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "018a7943",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n",
+    "\n",
+    "1. Describe the machine learning workflow.\n",
+    "2. What are model parameters?\n",
+    "3. What are coefficients and intercepts?\n",
+    "4. How does linear regression work?\n",
+    "5. Compare conda and pip for environment management.\n",
+    "6. Define MCAR, MAR, and MNAR.\n",
+    "7. When would you choose median imputation over mean, and why?\n",
+    "8. Which missingness type applies when the probability of missingness depends on the unobserved value itself?\n",
+    "\n",
+    "Write your answers below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb9a162f",
    "metadata": {},
    "source": [
     "*Your answers here.*\n"

--- a/exam/Mohanad_Ayman.ipynb
+++ b/exam/Mohanad_Ayman.ipynb
@@ -2,15 +2,19 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "c5bce25b",
    "metadata": {},
    "source": [
-    "# Exam for Mohanad Ayman\n\nThis exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
+    "# Exam for Mohanad Ayman\n",
+    "\n",
+    "This exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "b8477c27",
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -22,7 +26,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -33,15 +37,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "837444d1",
    "metadata": {},
    "source": [
-    "## Task 1: Data Cleaning\n\n- Handle missing values.\n- Remove duplicate rows.\n- Address outliers.\n- Document each step.\n"
+    "## Task 1: Data Cleaning\n",
+    "\n",
+    "- Handle missing values.\n",
+    "- Remove duplicate rows.\n",
+    "- Address outliers.\n",
+    "- Document each step.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "340fb8bc",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your data cleaning code here\n"
@@ -49,15 +60,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "85110e8c",
    "metadata": {},
    "source": [
-    "## Task 2: Summaries and Normalization\n\n- Provide summary statistics.\n- Normalize the numeric columns.\n- Explain the changes after normalization.\n"
+    "## Task 2: Summaries and Normalization\n",
+    "\n",
+    "- Provide summary statistics.\n",
+    "- Normalize the numeric columns.\n",
+    "- Explain the changes after normalization.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "d8a043bb",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your code for summary and normalization here\n"
@@ -65,15 +82,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "12833957",
    "metadata": {},
    "source": [
-    "## Task 3: Plotting\n\n- Plot histograms for each numeric column.\n- Create a scatter plot comparing two columns of your choice.\n- Comment on the patterns you observe.\n"
+    "## Task 3: Plotting\n",
+    "\n",
+    "- Plot histograms for each numeric column.\n",
+    "- Create a scatter plot comparing two columns of your choice.\n",
+    "- Comment on the patterns you observe.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "dbcad4df",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your plotting code here\n"
@@ -81,13 +104,113 @@
   },
   {
    "cell_type": "markdown",
+   "id": "db169150",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. What is a correlation matrix?\n2. What does the variance of the data indicate?\n3. How does linear regression work?\n4. What is mean squared error (MSE)?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n",
+    "\n",
+    "- Convert all column names to lowercase.\n",
+    "- Ensure column names have no spaces.\n",
+    "- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "67e9d021",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "8aee8892",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n",
+    "\n",
+    "- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n",
+    "- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28043f4b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21f016ce",
+   "metadata": {},
+   "source": [
+    "## Task 6: Filtering and Grouping\n",
+    "\n",
+    "- Filter rows where `A` is greater than 0 and `C` is not `NaN`.\n",
+    "- Group the filtered data by `C` and compute the mean of `B` for each group.\n",
+    "- Discuss any patterns you observe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "24677a57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for filtering and grouping here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1f60163",
+   "metadata": {},
+   "source": [
+    "## Task 7: Feature Engineering with `np.where`\n",
+    "\n",
+    "- Create a new column `a_label` that labels values of `A` as `'high'` if above the mean, otherwise `'low'`.\n",
+    "- Use `np.where` to implement the labeling.\n",
+    "- Display the count of each label."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4b540ba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your feature engineering code here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e0da89b",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n",
+    "\n",
+    "1. Describe the machine learning workflow.\n",
+    "2. What are model parameters?\n",
+    "3. What are coefficients and intercepts?\n",
+    "4. How does linear regression work?\n",
+    "5. Compare conda and pip for environment management.\n",
+    "6. Define MCAR, MAR, and MNAR.\n",
+    "7. When would you choose median imputation over mean, and why?\n",
+    "8. Which missingness type applies when the probability of missingness depends on the unobserved value itself?\n",
+    "\n",
+    "Write your answers below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e605314",
    "metadata": {},
    "source": [
     "*Your answers here.*\n"

--- a/exam/Mostafa_Abdelghany.ipynb
+++ b/exam/Mostafa_Abdelghany.ipynb
@@ -2,15 +2,19 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "875d5247",
    "metadata": {},
    "source": [
-    "# Exam for Mostafa Abdelghany\n\nThis exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
+    "# Exam for Mostafa Abdelghany\n",
+    "\n",
+    "This exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "60b76a2f",
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -22,7 +26,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -33,15 +37,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2e52b071",
    "metadata": {},
    "source": [
-    "## Task 1: Data Cleaning\n\n- Handle missing values.\n- Remove duplicate rows.\n- Address outliers.\n- Document each step.\n"
+    "## Task 1: Data Cleaning\n",
+    "\n",
+    "- Handle missing values.\n",
+    "- Remove duplicate rows.\n",
+    "- Address outliers.\n",
+    "- Document each step.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "bdc29932",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your data cleaning code here\n"
@@ -49,15 +60,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "03190daa",
    "metadata": {},
    "source": [
-    "## Task 2: Summaries and Normalization\n\n- Provide summary statistics.\n- Normalize the numeric columns.\n- Explain the changes after normalization.\n"
+    "## Task 2: Summaries and Normalization\n",
+    "\n",
+    "- Provide summary statistics.\n",
+    "- Normalize the numeric columns.\n",
+    "- Explain the changes after normalization.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "9411e886",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your code for summary and normalization here\n"
@@ -65,15 +82,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "791c386e",
    "metadata": {},
    "source": [
-    "## Task 3: Plotting\n\n- Plot histograms for each numeric column.\n- Create a scatter plot comparing two columns of your choice.\n- Comment on the patterns you observe.\n"
+    "## Task 3: Plotting\n",
+    "\n",
+    "- Plot histograms for each numeric column.\n",
+    "- Create a scatter plot comparing two columns of your choice.\n",
+    "- Comment on the patterns you observe.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "78231b66",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your plotting code here\n"
@@ -81,13 +104,113 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7e340855",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. How are training and testing performed?\n3. What does the variance of the data indicate?\n4. What is mean squared error (MSE)?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n",
+    "\n",
+    "- Convert all column names to lowercase.\n",
+    "- Ensure column names have no spaces.\n",
+    "- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33609341",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "1e2d49b2",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n",
+    "\n",
+    "- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n",
+    "- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "030e6b8a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b55458f4",
+   "metadata": {},
+   "source": [
+    "## Task 6: Filtering and Grouping\n",
+    "\n",
+    "- Filter rows where `A` is greater than 0 and `C` is not `NaN`.\n",
+    "- Group the filtered data by `C` and compute the mean of `B` for each group.\n",
+    "- Discuss any patterns you observe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18a35c88",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for filtering and grouping here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "452afc41",
+   "metadata": {},
+   "source": [
+    "## Task 7: Feature Engineering with `np.where`\n",
+    "\n",
+    "- Create a new column `a_label` that labels values of `A` as `'high'` if above the mean, otherwise `'low'`.\n",
+    "- Use `np.where` to implement the labeling.\n",
+    "- Display the count of each label."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11aebf3d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your feature engineering code here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb76dadb",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n",
+    "\n",
+    "1. Describe the machine learning workflow.\n",
+    "2. What are model parameters?\n",
+    "3. What are coefficients and intercepts?\n",
+    "4. How does linear regression work?\n",
+    "5. Compare conda and pip for environment management.\n",
+    "6. Define MCAR, MAR, and MNAR.\n",
+    "7. When would you choose median imputation over mean, and why?\n",
+    "8. Which missingness type applies when the probability of missingness depends on the unobserved value itself?\n",
+    "\n",
+    "Write your answers below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1cc54bb4",
    "metadata": {},
    "source": [
     "*Your answers here.*\n"

--- a/exam/Omar_Khaled.ipynb
+++ b/exam/Omar_Khaled.ipynb
@@ -2,15 +2,19 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "484b60f9",
    "metadata": {},
    "source": [
-    "# Exam for Omar Khaled\n\nThis exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
+    "# Exam for Omar Khaled\n",
+    "\n",
+    "This exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "e038e2c7",
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -22,7 +26,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -33,15 +37,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f9755a78",
    "metadata": {},
    "source": [
-    "## Task 1: Data Cleaning\n\n- Handle missing values.\n- Remove duplicate rows.\n- Address outliers.\n- Document each step.\n"
+    "## Task 1: Data Cleaning\n",
+    "\n",
+    "- Handle missing values.\n",
+    "- Remove duplicate rows.\n",
+    "- Address outliers.\n",
+    "- Document each step.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "39f451ad",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your data cleaning code here\n"
@@ -49,15 +60,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d7903abe",
    "metadata": {},
    "source": [
-    "## Task 2: Summaries and Normalization\n\n- Provide summary statistics.\n- Normalize the numeric columns.\n- Explain the changes after normalization.\n"
+    "## Task 2: Summaries and Normalization\n",
+    "\n",
+    "- Provide summary statistics.\n",
+    "- Normalize the numeric columns.\n",
+    "- Explain the changes after normalization.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "1bb864fb",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your code for summary and normalization here\n"
@@ -65,15 +82,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "52335ebb",
    "metadata": {},
    "source": [
-    "## Task 3: Plotting\n\n- Plot histograms for each numeric column.\n- Create a scatter plot comparing two columns of your choice.\n- Comment on the patterns you observe.\n"
+    "## Task 3: Plotting\n",
+    "\n",
+    "- Plot histograms for each numeric column.\n",
+    "- Create a scatter plot comparing two columns of your choice.\n",
+    "- Comment on the patterns you observe.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "a1061635",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your plotting code here\n"
@@ -81,13 +104,113 @@
   },
   {
    "cell_type": "markdown",
+   "id": "81c55164",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. How are training and testing performed?\n2. What is a correlation matrix?\n3. How does linear regression work?\n4. What is mean squared error (MSE)?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n",
+    "\n",
+    "- Convert all column names to lowercase.\n",
+    "- Ensure column names have no spaces.\n",
+    "- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81d7e1fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "4dadb6ed",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n",
+    "\n",
+    "- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n",
+    "- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8194a87",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bccc4be9",
+   "metadata": {},
+   "source": [
+    "## Task 6: Filtering and Grouping\n",
+    "\n",
+    "- Filter rows where `A` is greater than 0 and `C` is not `NaN`.\n",
+    "- Group the filtered data by `C` and compute the mean of `B` for each group.\n",
+    "- Discuss any patterns you observe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a28a796b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for filtering and grouping here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f35c76d5",
+   "metadata": {},
+   "source": [
+    "## Task 7: Feature Engineering with `np.where`\n",
+    "\n",
+    "- Create a new column `a_label` that labels values of `A` as `'high'` if above the mean, otherwise `'low'`.\n",
+    "- Use `np.where` to implement the labeling.\n",
+    "- Display the count of each label."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "206f2592",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your feature engineering code here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4acf671e",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n",
+    "\n",
+    "1. Describe the machine learning workflow.\n",
+    "2. What are model parameters?\n",
+    "3. What are coefficients and intercepts?\n",
+    "4. How does linear regression work?\n",
+    "5. Compare conda and pip for environment management.\n",
+    "6. Define MCAR, MAR, and MNAR.\n",
+    "7. When would you choose median imputation over mean, and why?\n",
+    "8. Which missingness type applies when the probability of missingness depends on the unobserved value itself?\n",
+    "\n",
+    "Write your answers below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "92a562e9",
    "metadata": {},
    "source": [
     "*Your answers here.*\n"

--- a/exam/Raneem_Mohammed.ipynb
+++ b/exam/Raneem_Mohammed.ipynb
@@ -2,15 +2,19 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "f47503ae",
    "metadata": {},
    "source": [
-    "# Exam for Raneem Mohammed\n\nThis exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
+    "# Exam for Raneem Mohammed\n",
+    "\n",
+    "This exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "1f18af14",
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -22,7 +26,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -33,15 +37,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5efbf640",
    "metadata": {},
    "source": [
-    "## Task 1: Data Cleaning\n\n- Handle missing values.\n- Remove duplicate rows.\n- Address outliers.\n- Document each step.\n"
+    "## Task 1: Data Cleaning\n",
+    "\n",
+    "- Handle missing values.\n",
+    "- Remove duplicate rows.\n",
+    "- Address outliers.\n",
+    "- Document each step.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "4e6d793d",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your data cleaning code here\n"
@@ -49,15 +60,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "74c102ba",
    "metadata": {},
    "source": [
-    "## Task 2: Summaries and Normalization\n\n- Provide summary statistics.\n- Normalize the numeric columns.\n- Explain the changes after normalization.\n"
+    "## Task 2: Summaries and Normalization\n",
+    "\n",
+    "- Provide summary statistics.\n",
+    "- Normalize the numeric columns.\n",
+    "- Explain the changes after normalization.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "36ab3db1",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your code for summary and normalization here\n"
@@ -65,15 +82,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "90530438",
    "metadata": {},
    "source": [
-    "## Task 3: Plotting\n\n- Plot histograms for each numeric column.\n- Create a scatter plot comparing two columns of your choice.\n- Comment on the patterns you observe.\n"
+    "## Task 3: Plotting\n",
+    "\n",
+    "- Plot histograms for each numeric column.\n",
+    "- Create a scatter plot comparing two columns of your choice.\n",
+    "- Comment on the patterns you observe.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "81bfe19e",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your plotting code here\n"
@@ -81,13 +104,113 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c2fa29dc",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. How are training and testing performed?\n3. What is a correlation matrix?\n4. How does linear regression work?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n",
+    "\n",
+    "- Convert all column names to lowercase.\n",
+    "- Ensure column names have no spaces.\n",
+    "- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b77da3e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "409dabc8",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n",
+    "\n",
+    "- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n",
+    "- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fdcf5c4c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e2490e70",
+   "metadata": {},
+   "source": [
+    "## Task 6: Filtering and Grouping\n",
+    "\n",
+    "- Filter rows where `A` is greater than 0 and `C` is not `NaN`.\n",
+    "- Group the filtered data by `C` and compute the mean of `B` for each group.\n",
+    "- Discuss any patterns you observe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7325d96e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for filtering and grouping here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad9469ae",
+   "metadata": {},
+   "source": [
+    "## Task 7: Feature Engineering with `np.where`\n",
+    "\n",
+    "- Create a new column `a_label` that labels values of `A` as `'high'` if above the mean, otherwise `'low'`.\n",
+    "- Use `np.where` to implement the labeling.\n",
+    "- Display the count of each label."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d08843d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your feature engineering code here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d56d87f9",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n",
+    "\n",
+    "1. Describe the machine learning workflow.\n",
+    "2. What are model parameters?\n",
+    "3. What are coefficients and intercepts?\n",
+    "4. How does linear regression work?\n",
+    "5. Compare conda and pip for environment management.\n",
+    "6. Define MCAR, MAR, and MNAR.\n",
+    "7. When would you choose median imputation over mean, and why?\n",
+    "8. Which missingness type applies when the probability of missingness depends on the unobserved value itself?\n",
+    "\n",
+    "Write your answers below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5469516",
    "metadata": {},
    "source": [
     "*Your answers here.*\n"

--- a/exam/Taha_Yassin_Mohamed.ipynb
+++ b/exam/Taha_Yassin_Mohamed.ipynb
@@ -2,15 +2,19 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "6e25fd71",
    "metadata": {},
    "source": [
-    "# Exam for Taha Yassin Mohamed\n\nThis exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
+    "# Exam for Taha Yassin Mohamed\n",
+    "\n",
+    "This exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "0cb62b03",
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -22,7 +26,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -33,15 +37,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1d623a27",
    "metadata": {},
    "source": [
-    "## Task 1: Data Cleaning\n\n- Handle missing values.\n- Remove duplicate rows.\n- Address outliers.\n- Document each step.\n"
+    "## Task 1: Data Cleaning\n",
+    "\n",
+    "- Handle missing values.\n",
+    "- Remove duplicate rows.\n",
+    "- Address outliers.\n",
+    "- Document each step.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "1a3854cf",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your data cleaning code here\n"
@@ -49,15 +60,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "06d7660e",
    "metadata": {},
    "source": [
-    "## Task 2: Summaries and Normalization\n\n- Provide summary statistics.\n- Normalize the numeric columns.\n- Explain the changes after normalization.\n"
+    "## Task 2: Summaries and Normalization\n",
+    "\n",
+    "- Provide summary statistics.\n",
+    "- Normalize the numeric columns.\n",
+    "- Explain the changes after normalization.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "0596e275",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your code for summary and normalization here\n"
@@ -65,15 +82,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "86370d6f",
    "metadata": {},
    "source": [
-    "## Task 3: Plotting\n\n- Plot histograms for each numeric column.\n- Create a scatter plot comparing two columns of your choice.\n- Comment on the patterns you observe.\n"
+    "## Task 3: Plotting\n",
+    "\n",
+    "- Plot histograms for each numeric column.\n",
+    "- Create a scatter plot comparing two columns of your choice.\n",
+    "- Comment on the patterns you observe.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "fd055b89",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your plotting code here\n"
@@ -81,13 +104,113 @@
   },
   {
    "cell_type": "markdown",
+   "id": "86d21b55",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. How are training and testing performed?\n3. What are coefficients and intercepts?\n4. What is the learning rate?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n",
+    "\n",
+    "- Convert all column names to lowercase.\n",
+    "- Ensure column names have no spaces.\n",
+    "- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cabe0975",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "ae2eaee8",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n",
+    "\n",
+    "- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n",
+    "- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "211d5107",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5dcb0f0",
+   "metadata": {},
+   "source": [
+    "## Task 6: Filtering and Grouping\n",
+    "\n",
+    "- Filter rows where `A` is greater than 0 and `C` is not `NaN`.\n",
+    "- Group the filtered data by `C` and compute the mean of `B` for each group.\n",
+    "- Discuss any patterns you observe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "296369a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for filtering and grouping here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8938940",
+   "metadata": {},
+   "source": [
+    "## Task 7: Feature Engineering with `np.where`\n",
+    "\n",
+    "- Create a new column `a_label` that labels values of `A` as `'high'` if above the mean, otherwise `'low'`.\n",
+    "- Use `np.where` to implement the labeling.\n",
+    "- Display the count of each label."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0e0a287",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your feature engineering code here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94594d1e",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n",
+    "\n",
+    "1. Describe the machine learning workflow.\n",
+    "2. What are model parameters?\n",
+    "3. What are coefficients and intercepts?\n",
+    "4. How does linear regression work?\n",
+    "5. Compare conda and pip for environment management.\n",
+    "6. Define MCAR, MAR, and MNAR.\n",
+    "7. When would you choose median imputation over mean, and why?\n",
+    "8. Which missingness type applies when the probability of missingness depends on the unobserved value itself?\n",
+    "\n",
+    "Write your answers below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d217eedf",
    "metadata": {},
    "source": [
     "*Your answers here.*\n"

--- a/exam/Yahya_Gad.ipynb
+++ b/exam/Yahya_Gad.ipynb
@@ -2,15 +2,19 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "62cad52d",
    "metadata": {},
    "source": [
-    "# Exam for Yahya Gad\n\nThis exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
+    "# Exam for Yahya Gad\n",
+    "\n",
+    "This exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "5e4a327d",
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -22,7 +26,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -33,15 +37,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "04fb8454",
    "metadata": {},
    "source": [
-    "## Task 1: Data Cleaning\n\n- Handle missing values.\n- Remove duplicate rows.\n- Address outliers.\n- Document each step.\n"
+    "## Task 1: Data Cleaning\n",
+    "\n",
+    "- Handle missing values.\n",
+    "- Remove duplicate rows.\n",
+    "- Address outliers.\n",
+    "- Document each step.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "ac7b02ba",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your data cleaning code here\n"
@@ -49,15 +60,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "02052697",
    "metadata": {},
    "source": [
-    "## Task 2: Summaries and Normalization\n\n- Provide summary statistics.\n- Normalize the numeric columns.\n- Explain the changes after normalization.\n"
+    "## Task 2: Summaries and Normalization\n",
+    "\n",
+    "- Provide summary statistics.\n",
+    "- Normalize the numeric columns.\n",
+    "- Explain the changes after normalization.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "cd090bb9",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your code for summary and normalization here\n"
@@ -65,15 +82,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ea7c56ee",
    "metadata": {},
    "source": [
-    "## Task 3: Plotting\n\n- Plot histograms for each numeric column.\n- Create a scatter plot comparing two columns of your choice.\n- Comment on the patterns you observe.\n"
+    "## Task 3: Plotting\n",
+    "\n",
+    "- Plot histograms for each numeric column.\n",
+    "- Create a scatter plot comparing two columns of your choice.\n",
+    "- Comment on the patterns you observe.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "6fa9a0f9",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your plotting code here\n"
@@ -81,13 +104,113 @@
   },
   {
    "cell_type": "markdown",
+   "id": "02526e36",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. Describe the machine learning workflow.\n2. What is a correlation matrix?\n3. What does the variance of the data indicate?\n4. How does linear regression work?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n",
+    "\n",
+    "- Convert all column names to lowercase.\n",
+    "- Ensure column names have no spaces.\n",
+    "- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5be429a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "24de0da3",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n",
+    "\n",
+    "- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n",
+    "- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "460f00bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "519dae4d",
+   "metadata": {},
+   "source": [
+    "## Task 6: Filtering and Grouping\n",
+    "\n",
+    "- Filter rows where `A` is greater than 0 and `C` is not `NaN`.\n",
+    "- Group the filtered data by `C` and compute the mean of `B` for each group.\n",
+    "- Discuss any patterns you observe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "39bb6b8f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for filtering and grouping here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd96ea7b",
+   "metadata": {},
+   "source": [
+    "## Task 7: Feature Engineering with `np.where`\n",
+    "\n",
+    "- Create a new column `a_label` that labels values of `A` as `'high'` if above the mean, otherwise `'low'`.\n",
+    "- Use `np.where` to implement the labeling.\n",
+    "- Display the count of each label."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31c9958e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your feature engineering code here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa903922",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n",
+    "\n",
+    "1. Describe the machine learning workflow.\n",
+    "2. What are model parameters?\n",
+    "3. What are coefficients and intercepts?\n",
+    "4. How does linear regression work?\n",
+    "5. Compare conda and pip for environment management.\n",
+    "6. Define MCAR, MAR, and MNAR.\n",
+    "7. When would you choose median imputation over mean, and why?\n",
+    "8. Which missingness type applies when the probability of missingness depends on the unobserved value itself?\n",
+    "\n",
+    "Write your answers below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "890902ec",
    "metadata": {},
    "source": [
     "*Your answers here.*\n"

--- a/exam/Yaseen_Moataz.ipynb
+++ b/exam/Yaseen_Moataz.ipynb
@@ -2,15 +2,19 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "bff51280",
    "metadata": {},
    "source": [
-    "# Exam for Yaseen Moataz\n\nThis exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
+    "# Exam for Yaseen Moataz\n",
+    "\n",
+    "This exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "908673eb",
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -22,7 +26,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -33,15 +37,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "34da2fb3",
    "metadata": {},
    "source": [
-    "## Task 1: Data Cleaning\n\n- Handle missing values.\n- Remove duplicate rows.\n- Address outliers.\n- Document each step.\n"
+    "## Task 1: Data Cleaning\n",
+    "\n",
+    "- Handle missing values.\n",
+    "- Remove duplicate rows.\n",
+    "- Address outliers.\n",
+    "- Document each step.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "36ca8e57",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your data cleaning code here\n"
@@ -49,15 +60,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4bf7b4b4",
    "metadata": {},
    "source": [
-    "## Task 2: Summaries and Normalization\n\n- Provide summary statistics.\n- Normalize the numeric columns.\n- Explain the changes after normalization.\n"
+    "## Task 2: Summaries and Normalization\n",
+    "\n",
+    "- Provide summary statistics.\n",
+    "- Normalize the numeric columns.\n",
+    "- Explain the changes after normalization.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "c25b73ca",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your code for summary and normalization here\n"
@@ -65,15 +82,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e2da7990",
    "metadata": {},
    "source": [
-    "## Task 3: Plotting\n\n- Plot histograms for each numeric column.\n- Create a scatter plot comparing two columns of your choice.\n- Comment on the patterns you observe.\n"
+    "## Task 3: Plotting\n",
+    "\n",
+    "- Plot histograms for each numeric column.\n",
+    "- Create a scatter plot comparing two columns of your choice.\n",
+    "- Comment on the patterns you observe.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "e87a0c47",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your plotting code here\n"
@@ -81,13 +104,113 @@
   },
   {
    "cell_type": "markdown",
+   "id": "119c4529",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. How are training and testing performed?\n2. What are model parameters?\n3. How does linear regression work?\n4. What is mean squared error (MSE)?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n",
+    "\n",
+    "- Convert all column names to lowercase.\n",
+    "- Ensure column names have no spaces.\n",
+    "- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4bf04f7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "18373a7e",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n",
+    "\n",
+    "- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n",
+    "- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21091f6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae60d35f",
+   "metadata": {},
+   "source": [
+    "## Task 6: Filtering and Grouping\n",
+    "\n",
+    "- Filter rows where `A` is greater than 0 and `C` is not `NaN`.\n",
+    "- Group the filtered data by `C` and compute the mean of `B` for each group.\n",
+    "- Discuss any patterns you observe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6538ed70",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for filtering and grouping here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "332fdbf3",
+   "metadata": {},
+   "source": [
+    "## Task 7: Feature Engineering with `np.where`\n",
+    "\n",
+    "- Create a new column `a_label` that labels values of `A` as `'high'` if above the mean, otherwise `'low'`.\n",
+    "- Use `np.where` to implement the labeling.\n",
+    "- Display the count of each label."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28e5a0b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your feature engineering code here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3978eb94",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n",
+    "\n",
+    "1. Describe the machine learning workflow.\n",
+    "2. What are model parameters?\n",
+    "3. What are coefficients and intercepts?\n",
+    "4. How does linear regression work?\n",
+    "5. Compare conda and pip for environment management.\n",
+    "6. Define MCAR, MAR, and MNAR.\n",
+    "7. When would you choose median imputation over mean, and why?\n",
+    "8. Which missingness type applies when the probability of missingness depends on the unobserved value itself?\n",
+    "\n",
+    "Write your answers below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8b37f8b",
    "metadata": {},
    "source": [
     "*Your answers here.*\n"

--- a/exam/Youssef_Khaled.ipynb
+++ b/exam/Youssef_Khaled.ipynb
@@ -2,15 +2,19 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "6914b958",
    "metadata": {},
    "source": [
-    "# Exam for Youssef Khaled\n\nThis exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
+    "# Exam for Youssef Khaled\n",
+    "\n",
+    "This exam covers concepts from Lab 00 and Lab 01. Use the provided random dataset to complete the tasks below. Document your results and explain your steps.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "1161142a",
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -22,7 +26,7 @@
     "    'A': np.random.randn(size),\n",
     "    'B': np.random.randn(size) * 50 + 20,\n",
     "    'C': np.random.choice([1, 2, 3, np.nan], size=size),\n",
-    "    'D': np.random.randn(size)\n",
+    "    'Column D': np.random.randn(size)\n",
     "})\n",
     "outliers = np.random.choice(size, 5, replace=False)\n",
     "data.loc[outliers, 'B'] *= 10\n",
@@ -33,15 +37,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a7faf163",
    "metadata": {},
    "source": [
-    "## Task 1: Data Cleaning\n\n- Handle missing values.\n- Remove duplicate rows.\n- Address outliers.\n- Document each step.\n"
+    "## Task 1: Data Cleaning\n",
+    "\n",
+    "- Handle missing values.\n",
+    "- Remove duplicate rows.\n",
+    "- Address outliers.\n",
+    "- Document each step.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "ae4310cd",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your data cleaning code here\n"
@@ -49,15 +60,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8f6f916f",
    "metadata": {},
    "source": [
-    "## Task 2: Summaries and Normalization\n\n- Provide summary statistics.\n- Normalize the numeric columns.\n- Explain the changes after normalization.\n"
+    "## Task 2: Summaries and Normalization\n",
+    "\n",
+    "- Provide summary statistics.\n",
+    "- Normalize the numeric columns.\n",
+    "- Explain the changes after normalization.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "298ca50d",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your code for summary and normalization here\n"
@@ -65,15 +82,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "27591005",
    "metadata": {},
    "source": [
-    "## Task 3: Plotting\n\n- Plot histograms for each numeric column.\n- Create a scatter plot comparing two columns of your choice.\n- Comment on the patterns you observe.\n"
+    "## Task 3: Plotting\n",
+    "\n",
+    "- Plot histograms for each numeric column.\n",
+    "- Create a scatter plot comparing two columns of your choice.\n",
+    "- Comment on the patterns you observe.\n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "id": "a491c1a5",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Your plotting code here\n"
@@ -81,13 +104,113 @@
   },
   {
    "cell_type": "markdown",
+   "id": "69e9869a",
    "metadata": {},
    "source": [
-    "## Written Questions\n\n1. How are training and testing performed?\n2. What are coefficients and intercepts?\n3. How does linear regression work?\n4. What is mean squared error (MSE)?\n\nWrite your answers below.\n"
+    "## Task 4: Column Standardization\n",
+    "\n",
+    "- Convert all column names to lowercase.\n",
+    "- Ensure column names have no spaces.\n",
+    "- Document the changes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69043fb9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for column standardization here\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "44bb4cf9",
+   "metadata": {},
+   "source": [
+    "## Task 5: Reproducibility Function\n",
+    "\n",
+    "- Write a function `repro_formula` that returns the string `R = f(code, data, environment)`.\n",
+    "- Call the function and display its output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a1e19f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your reproducibility function code here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd8166db",
+   "metadata": {},
+   "source": [
+    "## Task 6: Filtering and Grouping\n",
+    "\n",
+    "- Filter rows where `A` is greater than 0 and `C` is not `NaN`.\n",
+    "- Group the filtered data by `C` and compute the mean of `B` for each group.\n",
+    "- Discuss any patterns you observe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f3086a70",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your code for filtering and grouping here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5ef1e07",
+   "metadata": {},
+   "source": [
+    "## Task 7: Feature Engineering with `np.where`\n",
+    "\n",
+    "- Create a new column `a_label` that labels values of `A` as `'high'` if above the mean, otherwise `'low'`.\n",
+    "- Use `np.where` to implement the labeling.\n",
+    "- Display the count of each label."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29d181be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your feature engineering code here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6bbea63b",
+   "metadata": {},
+   "source": [
+    "## Written Questions\n",
+    "\n",
+    "1. Describe the machine learning workflow.\n",
+    "2. What are model parameters?\n",
+    "3. What are coefficients and intercepts?\n",
+    "4. How does linear regression work?\n",
+    "5. Compare conda and pip for environment management.\n",
+    "6. Define MCAR, MAR, and MNAR.\n",
+    "7. When would you choose median imputation over mean, and why?\n",
+    "8. Which missingness type applies when the probability of missingness depends on the unobserved value itself?\n",
+    "\n",
+    "Write your answers below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7f143b1",
    "metadata": {},
    "source": [
     "*Your answers here.*\n"


### PR DESCRIPTION
## Summary
- Add filtering and grouping exercise to deepen lab-based exam skills
- Introduce feature engineering task using `np.where` and expand written questions on imputation and missingness

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688dfc3bf60c832683bc92b6669f672a