### PR TITLE
Expand regression notebook with regularization examples

### DIFF
--- a/notebooks/03_Regression_Models.ipynb
+++ b/notebooks/03_Regression_Models.ipynb
@@ -140,6 +140,91 @@
   },
   {
    "cell_type": "markdown",
+   "id": "305ba979",
+   "metadata": {},
+   "source": [
+    "### L1 vs L2 Regularization\n",
+    "\n",
+    "L1 (lasso) adds the absolute value of coefficients to the loss, encouraging sparsity by driving some weights to exactly zero. L2 (ridge) adds the squared magnitude of coefficients, shrinking them toward zero but rarely eliminating features entirely."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b7acebf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ridge_preds = ridge.predict(X_test.iloc[:3])\n",
+    "lasso_preds = lasso.predict(X_test.iloc[:3])\n",
+    "pd.DataFrame({'Ridge': ridge_preds, 'Lasso': lasso_preds})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40a62406",
+   "metadata": {},
+   "source": [
+    "### Lasso as Feature Eliminator\n",
+    "Lasso can automatically drop irrelevant features by forcing their coefficients to zero."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "480b2458",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coef_series = pd.Series(lasso.coef_, index=X_train.columns)\n",
+    "eliminated_features = list(coef_series[coef_series == 0].index)\n",
+    "eliminated_features"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "482c7f61",
+   "metadata": {},
+   "source": [
+    "### ElasticNet Regression\n",
+    "Combines L1 and L2 penalties to balance between Ridge and Lasso."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6159aabc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.linear_model import ElasticNet\n",
+    "elastic = ElasticNet(alpha=0.1, l1_ratio=0.5, random_state=0).fit(X_train, y_train)\n",
+    "elastic.score(X_test, y_test)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "641cd052",
+   "metadata": {},
+   "source": [
+    "### Random Forest Regression\n",
+    "An ensemble of decision trees that reduces variance by averaging multiple trees."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47ea41c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.ensemble import RandomForestRegressor\n",
+    "rf = RandomForestRegressor(random_state=0).fit(X_train, y_train)\n",
+    "rf.score(X_test, y_test)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "proscons",
    "metadata": {},
    "source": [
@@ -253,7 +338,12 @@
     "5. Use `PolynomialFeatures` to fit a quadratic curve and compare it to the linear fit.\n",
     "6. Derive the normal equation yourself and verify the solution using NumPy.\n",
     "7. Implement `ElasticNet` and compare its performance to Ridge and Lasso.\n",
-    "8. Evaluate the model using mean absolute error and compare it with mean squared error."
+    "8. Evaluate the model using mean absolute error and compare it with mean squared error.\n",
+    "9. Use `Lasso` to eliminate features and retrain a linear regression model.\n",
+    "10. Train a `RandomForestRegressor` and inspect its feature importances.\n",
+    "11. Fit an `SVR` model and compare its predictions to linear regression.\n",
+    "12. Investigate how varying `alpha` affects `Ridge` and `Lasso` coefficient magnitudes.\n",
+    "13. Try scaling features before regularization and observe the impact on coefficients.\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- Explain L1 vs L2 regularization with side-by-side prediction comparison
- Demonstrate Lasso for feature elimination and add ElasticNet and Random Forest regressors
- Extend end-of-notebook exercises with additional questions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898288c1b208326981a1d3a5f312109