### PR TITLE
Add regularization penalty analysis

### DIFF
--- a/notebooks/03_Regression_Models.ipynb
+++ b/notebooks/03_Regression_Models.ipynb
@@ -225,6 +225,68 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2b65a479",
+   "metadata": {},
+   "source": [
+    "### Regularization Strength and Model Performance\n",
+    "To illustrate how adjusting the regularization penalty impacts performance, let's explore Ridge and Lasso regression on the diabetes dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f07765c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "from sklearn.datasets import load_diabetes\n",
+    "from sklearn.preprocessing import StandardScaler\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "X, y = load_diabetes(return_X_y=True)\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)\n",
+    "scaler = StandardScaler().fit(X_train)\n",
+    "X_train_scaled = scaler.transform(X_train)\n",
+    "X_test_scaled = scaler.transform(X_test)\n",
+    "\n",
+    "alphas = np.logspace(-3, 3, 7)\n",
+    "ridge_train, ridge_test, lasso_nonzero = [], [], []\n",
+    "\n",
+    "for alpha in alphas:\n",
+    "    ridge = Ridge(alpha=alpha).fit(X_train_scaled, y_train)\n",
+    "    ridge_train.append(ridge.score(X_train_scaled, y_train))\n",
+    "    ridge_test.append(ridge.score(X_test_scaled, y_test))\n",
+    "    lasso = Lasso(alpha=alpha, max_iter=10000).fit(X_train_scaled, y_train)\n",
+    "    lasso_nonzero.append(np.sum(lasso.coef_ != 0))\n",
+    "\n",
+    "plt.semilogx(alphas, ridge_train, label='Train $R^2$')\n",
+    "plt.semilogx(alphas, ridge_test, label='Test $R^2$')\n",
+    "plt.xlabel('alpha')\n",
+    "plt.ylabel('$R^2$')\n",
+    "plt.title('Ridge Regression Performance')\n",
+    "plt.legend()\n",
+    "plt.show()\n",
+    "\n",
+    "plt.semilogx(alphas, lasso_nonzero, marker='o')\n",
+    "plt.xlabel('alpha')\n",
+    "plt.ylabel('Non-zero coefficients')\n",
+    "plt.title('Lasso Feature Count')\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c63f180",
+   "metadata": {},
+   "source": [
+    "Increasing the penalty (`alpha`) shrinks coefficients. In Ridge, large `alpha` reduces both training and test scores due to high bias, while too small `alpha` can overfit. Lasso drives more coefficients to zero as `alpha` grows, highlighting its feature selection behavior."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "proscons",
    "metadata": {},
    "source": [


### PR DESCRIPTION
## Summary
- Explore Ridge and Lasso on diabetes data to visualize how penalty strength affects model performance
- Plot R^2 scores and non-zero coefficient counts across alphas
- Add interpretation explaining bias-variance trade-offs when tuning alpha

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68982c05a2ec8326807a35ff62ff6db2