### PR TITLE
Add lambda max explanation to regression notebook

### DIFF
--- a/notebooks/03_Regression_Models.ipynb
+++ b/notebooks/03_Regression_Models.ipynb
@@ -140,6 +140,35 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c2df972b",
+   "metadata": {},
+   "source": [
+    "To find the largest penalty value that still gives a non-zero model (often called $\\lambda_{\\text{max}}$ or $\\alpha_{\\text{max}}$), we use the fact that Lasso drops all coefficients to zero once the penalty exceeds the largest absolute correlation between any feature and the target.\n",
+    "\n",
+    "**Formula**\n",
+    "\n",
+    "$$\\lambda_{\\text{max}} = \\frac{1}{n} \\max_j |X_j^\\top y|$$\n",
+    "\n",
+    "Here, $X$ is the $n \\times p$ matrix of centered features and $y$ is the centered response vector. $X_j$ denotes the $j$-th column of $X$.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "512fcc43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "# X: (n, p) design matrix with centered columns\n",
+    "# y: (n,) target vector, centered\n",
+    "n = X.shape[0]\n",
+    "alpha_max = np.max(np.abs(X.T @ y)) / n\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "305ba979",
    "metadata": {},
    "source": [


### PR DESCRIPTION
## Summary
- explain how to determine the maximum Lasso penalty that keeps coefficients non-zero
- include Python snippet to compute `alpha_max`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68982db9b078832694fa991939b280f4